### PR TITLE
Fix README API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-3. Create a `.env` file with your OpenAI API key:
+3. Create a `.env` file with your Google Generative AI API key:
 ```
-OPENAI_API_KEY=your_api_key_here
+GOOGLE_API_KEY=your_api_key_here
 ```
 
 ## Project Structure


### PR DESCRIPTION
## Summary
- fix instructions for `.env` API key name

## Testing
- `python -m py_compile src/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6848fe69db8c832abec23a6e1d2dc40d